### PR TITLE
feat: add a new step to calculate stack versions when multiple minors are in play

### DIFF
--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -40,6 +40,7 @@ projects:
       - main
       - 8.<minor>
       - 7.<minor>
+      - 7.<minor-1>
     enabled: true
     reusePullRequest: false
     labels: dependency,backport-skip

--- a/.ci/.bump-stack-version.yml
+++ b/.ci/.bump-stack-version.yml
@@ -1,0 +1,55 @@
+---
+## This is the file that contains what projects should bump their elastic stack
+## versions.
+##
+## The data structure:
+##  repo: the repository name
+##  script: the relative path to the script in charge to bump the version
+##  branches: the list of branches that should benefit from this automation.
+##  enabled: whether the automation has been enabled for this project.
+##  reusePullRequest: whether to reuse the existing opened Pull Request.
+##  labels: list of GitHub labels to be added to the Pull Request (comma separated).
+##
+##  NOTE:
+##  <minor> is a special token that refers to the latest minor branch. The automation
+##          will resolve the correct version at runtime, so you don't need to change it.
+##
+projects:
+  - repo: apm-server
+    script: .ci/bump-stack-version.sh
+    branches:
+      - master
+      - 8.<minor>
+      - 7.<minor>
+    enabled: true
+    reusePullRequest: false
+    labels: dependency,backport-skip
+  - repo: beats
+    script: .ci/bump-stack-version.sh
+    branches:
+      - master
+      - 8.<minor>
+      - 7.<minor>
+      - "6.8"
+    enabled: true
+    reusePullRequest: false
+    labels: dependency,build-monitoring,backport-skip,Team:Beats-On-Call
+  - repo: e2e-testing
+    script: .ci/bump-stack-version.sh
+    branches:
+      - main
+      - 8.<minor>
+      - 7.<minor>
+    enabled: true
+    reusePullRequest: false
+    labels: dependency,backport-skip
+    reviewer: elastic/observablt-robots-on-call
+  - repo: fleet-server
+    script: .ci/bump-stack-version.sh
+    branches:
+      - master
+      - 8.<minor>
+      - 7.<minor>
+    enabled: true
+    reusePullRequest: false
+    labels: dependency,backport-skip

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -25,7 +25,7 @@ import groovy.transform.Field
 pipeline {
   agent { label 'linux && immutable' }
   environment {
-    REPO = 'observability-dev'
+    REPO = 'apm-pipeline-library'
     ORG_NAME = 'elastic'
     HOME = "${env.WORKSPACE}"
     NOTIFY_TO = credentials('notify-to')

--- a/.ci/bumpStackVersion.groovy
+++ b/.ci/bumpStackVersion.groovy
@@ -117,7 +117,7 @@ def prepareArguments(Map args = [:]){
   def reviewer = args.get('reviewer', '')
   log(level: 'INFO', text: "prepareArguments(repo: ${repo}, branch: ${branch}, scriptFile: ${scriptFile}, reusePullRequest: ${reusePullRequest}, labels: '${labels}')")
   def title = '[automation] update elastic stack version for testing'
-  def branchName = findBranchName(branch: branch, versions: latestVersions)
+  def branchName = getBranchNameFromArtifactsAPI(branch: branch)
   def versionEntry = latestVersions.get(branchName)
   def message = """### What \n Bump stack version with the latest one. \n ### Further details \n ${versionEntry}"""
   def stackVersion = versionEntry?.build_id
@@ -193,15 +193,4 @@ def reusePullRequestIfPossible(Map args = [:]){
   }
   log(level: 'INFO', text: 'Could not find a GitHub Pull Request. So fallback to create a new one instead.')
   return false
-}
-
-def findBranchName(Map args = [:]){
-  def branch = args.branch
-  // special macro to look for the latest minor version
-  if (branch.contains('<minor>')) {
-    def parts = branch.split('\\.')
-    def major = parts[0]
-    branch = args.versions.collect{ k,v -> k }.findAll { it ==~ /${major}\.\d+/ }.sort().last()
-  }
-  return branch
 }

--- a/src/test/groovy/GetBranchNameFromArtifactsAPIStepTests.groovy
+++ b/src/test/groovy/GetBranchNameFromArtifactsAPIStepTests.groovy
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.junit.Before
+import org.junit.Test
+
+class GetBranchNameFromArtifactsAPIStepTests extends ApmBasePipelineTest {
+
+  @Override
+  @Before
+  void setUp() throws Exception {
+    super.setUp()
+    script = loadScript('vars/getBranchNameFromArtifactsAPI.groovy')
+    helper.registerAllowedMethod('artifactsApi', [Map.class], { f ->
+      return [
+        "7.14": ["version": "7.16.3-SNAPSHOT"],
+        "7.15": ["version": "7.16.3-SNAPSHOT"],
+        "7.16": ["version": "7.16.3-SNAPSHOT"],
+        "7.17": ["version": "7.16.3-SNAPSHOT"],
+        "7.18": ["version": "7.16.3-SNAPSHOT"],
+        "8.0": ["version": "7.16.3-SNAPSHOT"]
+      ]
+    })
+  }
+
+  @Test
+  void test_missing_argument() throws Exception {
+    testMissingArgument('branch') {
+      script.call()
+    }
+  }
+
+  @Test
+  void test_branch() throws Exception {
+    def ret = script.call(branch: "8.0")
+
+    printCallStack()
+    assert ret.equals('8.0')
+  }
+
+  @Test
+  void test_minor() throws Exception {
+    def ret = script.call(branch: "7.<minor>")
+
+    printCallStack()
+    assert ret.equals('7.18')
+  }
+
+  @Test
+  void test_minor_minus_NaN_retrieves_last() throws Exception {
+    def ret = script.call(branch: "7.<minor-asdfg>")
+
+    printCallStack()
+    assert ret.equals('7.18')
+  }
+
+  @Test
+  void test_minor_minus_0_retrieves_last() throws Exception {
+    def ret = script.call(branch: "7.<minor-0>")
+
+    printCallStack()
+    assert ret.equals('7.18')
+  }
+
+  @Test
+  void test_minor_minus_1() throws Exception {
+    def ret = script.call(branch: "7.<minor-1>")
+
+    printCallStack()
+    assert ret.equals('7.17')
+  }
+
+  @Test
+  void test_minor_minus_2() throws Exception {
+    def ret = script.call(branch: "7.<minor-2>")
+
+    printCallStack()
+    assert ret.equals('7.16')
+  }
+
+  @Test
+  void test_minor_minus_more_than_size_retrieves_first() throws Exception {
+    def ret = script.call(branch: "7.<minor-500>")
+
+    printCallStack()
+    assert ret.equals('7.14')
+  }
+}

--- a/vars/README.md
+++ b/vars/README.md
@@ -639,6 +639,25 @@ def testURL = getBlueoceanTabURL('test')
 def artifactURL = getBlueoceanTabURL('artifact')
 ```
 
+## getBranchNameFromArtifactsAPI
+Find the branch name for a stack version in the Artifacts API given the conditions to compare with.
+
+The step supports passing a minor version, returning the branch name including that minor (i.e. 7.15), or passing a version token in the
+'<minor>' format. This format supports passing an index, separated by the minus operator: '<minor-1>', which will retrieve the previous
+version for the last minor. If the index overflows the number of the total existing minors, the first minor will be retrieved (i.e.
+'<minor-1999>').
+
+The more common use case is when there are two minor versions in development at the same time: 7.16 and 7.17
+
+```
+  getBranchNameFromArtifactsAPI(branch: '7.0')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor>')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor-1>')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor-2>')
+```
+
+* branch: the branch name or supported pattern. Mandatory
+
 ## getBuildInfoJsonFiles
 Grab build related info from the Blueocean REST API and store it on JSON files.
 Then put all togeder in a simple JSON file.

--- a/vars/getBranchNameFromArtifactsAPI.groovy
+++ b/vars/getBranchNameFromArtifactsAPI.groovy
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+Find the branch name for a stack version in the Artifacts API given the conditions to compare with.
+
+The step supports passing a minor version, returning the branch name including that minor (i.e. 7.15), or passing a version token in the
+'<minor>' format. This format supports passing an index, separated by the minus operator: '<minor-1>', which will retrieve the previous
+version for the last minor. If the index overflows the number of the total existing minors, the first minor will be retrieved (i.e.
+'<minor-1999>').
+
+The more common use case is when there are two minor versions in development at the same time: 7.16 and 7.17
+
+def branchName7minor = getBranchNameFromArtifactsAPI(branch: '7.<minor>')
+def branchName7Zero = getBranchNameFromArtifactsAPI(branch: '7.0')
+def branchName7Minor = getBranchNameFromArtifactsAPI(branch: '7.<minor>')
+def branchName7Minor1 = getBranchNameFromArtifactsAPI(branch: '7.<minor-1>')
+def branchName7Minor2 = getBranchNameFromArtifactsAPI(branch: '7.<minor-2>')
+*/
+
+def call(Map args = [:]) {
+  def branch = args.containsKey('branch') ? args.branch : error('getBranchNameFromArtifactsAPI: branch parameter is required')
+
+  // To store all the latest snapshot versions
+  def latestVersions = artifactsApi(action: 'latest-versions')
+
+  def parts = branch.split('\\.')
+  def major = parts[0]
+  def minor
+  if (parts.size() > 0) {
+    minor = parts[1]
+    minor = minor.replaceAll("<", "")
+    minor = minor.replaceAll(">", "")
+  }
+
+    // special macro to look for the latest minor version
+  if (minor.contains('-')) {
+    def minorParts = minor.split('-')
+    minor = minorParts[0]
+
+    // parse second part of the minor token
+    def index = minorParts[1]
+    try {
+      index = Integer.parseInt(index)
+    } catch (Exception ex) {
+      println("Index will be considered as zero: " + ex)
+      index = 0
+    }
+
+    def matchingVersions = latestVersions.collect{ k,v -> k }.findAll { it ==~ /${major}\.\d+/ }.sort()
+
+    int size = matchingVersions.size()
+
+    def retIndex = size - index - 1
+    if (retIndex < 0) {
+      retIndex = 0 // min limit
+    } else if (retIndex >= size) {
+      retIndex = size - 1 // max limit
+    }
+
+    return matchingVersions.get(retIndex)
+  }
+
+  // special macro to look for the latest minor version
+  if (minor.equals('minor')) {
+    return latestVersions.collect{ k,v -> k }.findAll { it ==~ /${major}\.\d+/ }.sort().last()
+  }
+
+  return branch
+}

--- a/vars/getBranchNameFromArtifactsAPI.txt
+++ b/vars/getBranchNameFromArtifactsAPI.txt
@@ -1,0 +1,17 @@
+Find the branch name for a stack version in the Artifacts API given the conditions to compare with.
+
+The step supports passing a minor version, returning the branch name including that minor (i.e. 7.15), or passing a version token in the
+'<minor>' format. This format supports passing an index, separated by the minus operator: '<minor-1>', which will retrieve the previous
+version for the last minor. If the index overflows the number of the total existing minors, the first minor will be retrieved (i.e.
+'<minor-1999>').
+
+The more common use case is when there are two minor versions in development at the same time: 7.16 and 7.17
+
+```
+  getBranchNameFromArtifactsAPI(branch: '7.0')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor>')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor-1>')
+  getBranchNameFromArtifactsAPI(branch: '7.<minor-2>')
+```
+
+* branch: the branch name or supported pattern. Mandatory


### PR DESCRIPTION
- chore: copy stack version bumps from oblt-dev
- chore: use apm-pipeline library as repository for stack version bumps
- feat: add a step to retrieve the branch name supporting multiple minors
- chore: use new step to retrieve the branch name for the stack update

## What does this PR do?
It adds a new step that supports passing a branch with a specific format:

- major.minor
- major.<minor>
- major.<minor-$index>

The index will be used to retrieve a previous minor version of the stack

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
It could be the case where there are multiple minors in development at the same time, 7.16 and 7.17, and with previous behaviour, the automation discarded those cases where the project needed a bump in two minors (See e2e-tests, that needs bumps in 7.16 and 7.17)


<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

