### PR TITLE
fix: use same errorGithubPrCheckApproved condition

### DIFF
--- a/resources/github-comment-markdown.template
+++ b/resources/github-comment-markdown.template
@@ -79,7 +79,7 @@ ${errorStackTrace}
 <% stepsErrors = stepsErrors?.findAll{it?.result == "FAILURE" &&
                                       !it?.displayName?.contains('Notifies GitHub') &&
                                       !it?.displayName?.contains('Archive JUnit') &&
-                                      !it?.displayDescription?.contains('githubPrCheckApproved') &&
+                                      errorGithubPrCheckApproved &&
                                       !it?.displayDescription?.contains('approval-list/elastic') &&
                                       !it?.displayName?.contains('Recursively delete the current directory from the workspace')}%>
 <% errorSignal = stepsErrors?.find{it?.displayName?.contains('Error signal')}%>


### PR DESCRIPTION
## What does this PR do?

The stepsError variable was using part of the errorGithubPrCheckApproved
condition, and with this change we are covering the usage when the
displayDescription is not an instance of net.sf.json.JSONNull


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Why is it important?
We are seeing the following error in certain pipelines:

```
[2022-05-30T07:08:06.039Z] ERROR: generateBuildReport: Error generating build report
[2022-05-30T07:08:06.040Z] groovy.lang.MissingMethodException: No signature of method: net.sf.json.JSONNull.contains() is applicable for argument types: (java.lang.String) values: [githubPrCheckApproved]
[2022-05-30T07:08:06.040Z] Possible solutions: toString(), toString(), toString(), notify(), toString(int)
[2022-05-30T07:08:06.040Z] 	at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.findAll(CpsDefaultGroovyMethods.java:1068)
[2022-05-30T07:08:06.040Z] Caused: groovy.text.TemplateExecutionException: Template execution error at line 82:
[2022-05-30T07:08:06.040Z]         81:                                       !it?.displayName?.contains('Archive JUnit') &&
[2022-05-30T07:08:06.040Z]     --> 82:                                       !it?.displayDescription?.contains('githubPrCheckApproved') &&
[2022-05-30T07:08:06.040Z]         83:                                       !it?.displayDescription?.contains('approval-list/elastic') &&
```

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

